### PR TITLE
Fixed inventory slot overrides breaking 1.27 vanilla bag attachments

### DIFF
--- a/Spur_BagZ/Spur_Modded_Vanilla/config.cpp
+++ b/Spur_BagZ/Spur_Modded_Vanilla/config.cpp
@@ -36,7 +36,7 @@ class cfgVehicles
 	};
 	class KukriKnife: Inventory_Base
 	{
-		inventorySlot[]=
+		inventorySlot[]+=
 		{
 			"KukriKnife",
 			"KukriKnife2",
@@ -53,7 +53,7 @@ class cfgVehicles
 	};
 	class FangeKnife: Inventory_Base
 	{
-		inventorySlot[]=
+		inventorySlot[]+=
 		{
 			"Knife",
 			"FangeKnife",
@@ -71,7 +71,7 @@ class cfgVehicles
 	};
 	class Hatchet: Inventory_Base
 	{
-		inventorySlot[]=
+		inventorySlot[]+=
 		{
 			"MassTool",
 			"Hatchet",
@@ -90,7 +90,7 @@ class cfgVehicles
 	};
 	class OrientalMachete: Inventory_Base
 	{
-		inventorySlot[]=
+		inventorySlot[]+=
 		{
 			"OrientalMachete",
 			"OrientalMachete2",
@@ -107,7 +107,7 @@ class cfgVehicles
 	};
 	class CrudeMachete: Inventory_Base
 	{
-		inventorySlot[]=
+		inventorySlot[]+=
 		{
 			"CrudeMachete",
 			"CrudeMachete2",


### PR DESCRIPTION
The new 1.27 proxy bag attachments for Vanilla Hatchet and the machete types was being overridden by this mod 